### PR TITLE
Support wavefront formatted status output 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ifeq ($(MCS),)
   MCS := /usr/bin/dmcs
 endif
 
-CFLAGS := -Werror -Wno-error=format -fPIC -DNO_INTELLISENSE -fvisibility=hidden -DNDEBUG=1 -Wreturn-type -fno-omit-frame-pointer
+CFLAGS := -Wno-error=format -fPIC -DNO_INTELLISENSE -fvisibility=hidden -DNDEBUG=1 -Wreturn-type -fno-omit-frame-pointer
 ifeq ($(RELEASE),true)
 	CFLAGS += -DFDB_CLEAN_BUILD
 endif

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ifeq ($(MCS),)
   MCS := /usr/bin/dmcs
 endif
 
-CFLAGS := -Wno-error=format -fPIC -DNO_INTELLISENSE -fvisibility=hidden -DNDEBUG=1 -Wreturn-type -fno-omit-frame-pointer
+CFLAGS := -Werror -Wno-error=format -fPIC -DNO_INTELLISENSE -fvisibility=hidden -DNDEBUG=1 -Wreturn-type -fno-omit-frame-pointer
 ifeq ($(RELEASE),true)
 	CFLAGS += -DFDB_CLEAN_BUILD
 endif

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -745,14 +745,14 @@ void serializeJsonObj(StatusObjectReader &payload, const std::string &source,
 					tags["machine_id"] = dic.find("machine_id")->second.get_str();
 					dic.erase(dic.find("machine_id"));
 				}
-                JSONDoc newPayload(dic);
+				JSONDoc newPayload(dic);
 				if(path == "cluster.processes"){
 					tags["process_id"] = key;
 					// extract port info
 					std::vector<std::string> address;
 					boost::split(address, tags["address"], boost::is_any_of(":"));
-                    tags["address"] = address[0];
-                    serializeJsonObj(newPayload, source, tags, path + separator + address[1]);
+					tags["address"] = address[0];
+					serializeJsonObj(newPayload, source, tags, path + separator + address[1]);
 				} else if (path == "cluster.machines" && tags["machine_id"] == key){
 				    // don't include machine_id inside metric name
 					serializeJsonObj(newPayload, source, tags, path);
@@ -780,8 +780,7 @@ void serializeJsonObj(StatusObjectReader &payload, const std::string &source,
 				}
 				// create a metric where name is its role and value is 1.0
 				// e.g "cluster.processes.4689.role.master" "1.000000"
-				std::string metric =
-						metricsToLineData(path + separator + role, 1.0, -1, source, tags);
+				std::string metric = metricsToLineData(path + separator + role, 1.0, -1, source, tags);
 				printf("%s\n", metric.c_str());
 
 				JSONDoc newPayload(dic);

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -778,7 +778,7 @@ void serializeJsonObj(StatusObjectReader &payload, const std::string &source,
 					role += dic.find("role")->second.get_str();
 					dic.erase(dic.find("role"));
 				}
-				// create a metric where name is role and value is 1.0
+				// create a metric where name is its role and value is 1.0
 				// e.g "cluster.processes.4689.role.master" "1.000000"
 				std::string metric =
 						metricsToLineData(path + separator + role, 1.0, -1, source, tags);

--- a/fdbclient/StatusClient.h
+++ b/fdbclient/StatusClient.h
@@ -26,7 +26,7 @@
 
 class StatusClient {
 public:
-	enum StatusLevel { MINIMAL = 0, NORMAL = 1, DETAILED = 2, JSON = 3 };
+	enum StatusLevel { MINIMAL = 0, NORMAL = 1, DETAILED = 2, JSON = 3, WAVEFRONT = 4 };
 	static Future<StatusObject> statusFetcher(Reference<ClusterConnectionFile> clusterFile);
 };
 

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -25,8 +25,6 @@
 #include "flow/ActorCollection.h"
 #include "fdbclient/Notified.h"
 #include "fdbclient/SystemData.h"
-#include "fdbclient/CoordinationInterface.h"
-#include "fdbclient/StatusClient.h"
 
 #define OP_DISK_OVERHEAD (sizeof(OpHeader) + 1)
 
@@ -429,34 +427,6 @@ private:
 		return log->push( LiteralStringRef("\x01") ); // Changes here should be reflected in OP_DISK_OVERHEAD
 	}
 
-	// reset everything and join as an empty node
-	static void join_as_empty(KeyValueStoreMemory* self){
-		self->previousSnapshotEnd = -1;
-		self->currentSnapshotEnd = -1;
-		self->resetSnapshot = false;
-		self->committedWriteBytes = self->committedDataSize = 0;
-		self->transactionSize = 0;
-		self->transactionIsLarge = false;
-		// clear data set and operation queue
-		self->data.clear();
-		self->queue.clear();
-	}
-
-	// check if cluster is healthy, private method used by recovery process
-	ACTOR static Future<bool> is_cluster_healthy(){
-		// TODO: user can specify cluster file name
-		state std::pair<std::string, bool> resolvedClusterFile = ClusterConnectionFile::lookupClusterFileName("");
-		state Reference<ClusterConnectionFile> ccf( new ClusterConnectionFile( resolvedClusterFile.first ) );
-		StatusObject statusObj = wait(StatusClient::statusFetcher(ccf));
-
-		// retrieve cluster healthy status
-		// TODO: which healthy data to be used
-		StatusObjectReader statusObjectReader(statusObj);
-		StatusObjectReader statusObjClient = statusObjectReader["client"].get_obj();
-		StatusObjectReader statusObjClientDatabaseStatus = statusObjClient["database_status"].get_obj();
-		return statusObjClientDatabaseStatus["healthy"].get_bool();
-	}
-
     ACTOR static Future<Void> recover( KeyValueStoreMemory* self, bool exactRecovery ) {
 		// 'uncommitted' variables track something that might be rolled back by an OpRollback, and are copied into permanent variables
 		// (in self) in OpCommit.  OpRollback does the reverse (copying the permanent versions over the uncommitted versions)
@@ -576,22 +546,13 @@ private:
 				}
 
 				if (loggingDelay.isReady()) {
-					state bool isHealthy = wait(is_cluster_healthy());
 					TraceEvent("KVSMemRecoveryLogSnap", self->id)
-					    .detail("IsHealthy", isHealthy)
-						.detail("SnapshotItems", dbgSnapshotItemCount)
-						.detail("SnapshotEnd", dbgSnapshotEndCount)
-						.detail("Mutations", dbgMutationCount)
-						.detail("Commits", dbgCommitCount)
-						.detail("EndsAt", self->log->getNextReadLocation());
-					if(isHealthy){
-						// if cluster is healthy, reset everything and return as an empty node
-						join_as_empty(self);
-						return Void();
-					} else{
-						loggingDelay = delay(2.0);
-						loggingDelay = delay(2.0);
-					}
+							.detail("SnapshotItems", dbgSnapshotItemCount)
+							.detail("SnapshotEnd", dbgSnapshotEndCount)
+							.detail("Mutations", dbgMutationCount)
+							.detail("Commits", dbgCommitCount)
+							.detail("EndsAt", self->log->getNextReadLocation());
+					loggingDelay = delay(1.0);
 				}
 
 				Void _ = wait( yield() );


### PR DESCRIPTION
By following Michael’s [python script](https://github.com/sunnylabs/ansible/blob/master/roles/telegraf/templates/scripts/parse-fdb-status.py), I’ve modified foundationdb source file (mainly **fdbcli.actor.cpp**) so that every time we run command line
```
fdbcli —exec "status wavefront"
```
we can parse the returned json status object and turn it into wavefront supported metrics format. Also with several improvements based on the discussion we have.
(1) remove `excluded` from tags, and add metric like `cluster.processes.4604.excluded = [0|1]`. 0 represents false and 1 represents true. 
(2)  add rule_id as a point tag and add metric name like `cluster.processes.4604.rule.master = [0|1]` (the name indicates that fdb process on port 4604 has the rule as master)

And please see attachments for command line output.
[output.txt](https://github.com/wavefrontHQ/foundationdb/files/2650100/output2.txt)